### PR TITLE
Fix sleep message sleeping player count

### DIFF
--- a/src/main/java/net/lavabucket/hourglass/chat/HourglassMessages.java
+++ b/src/main/java/net/lavabucket/hourglass/chat/HourglassMessages.java
@@ -44,7 +44,7 @@ public class HourglassMessages {
     @SubscribeEvent
     public static void onSleepingCheckEvent(SleepingTimeCheckEvent event) {
         PlayerEntity player = event.getPlayer();
-        if (!player.level.isClientSide() && player.isSleeping() && player.getSleepTimer() == 1
+        if (!player.level.isClientSide() && player.isSleeping() && player.getSleepTimer() == 2
                 && player.level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)) {
             sendSleepMessage(event.getPlayer());
         }


### PR DESCRIPTION
This commit fixes an issue introduced in version 1.1.1.1 where sleep
messages display the number of sleeping players as one less than the
correct amount.

Fixes: #11